### PR TITLE
batch processing baby

### DIFF
--- a/particles/photon.py
+++ b/particles/photon.py
@@ -15,20 +15,17 @@ class photon(IParticle):
         self.t = t
         self._dx, self._dy, self._dz = self._calculate_direction()
 
-    def _calculate_direction(self):
-        if self.pz < 0 and self.pz != 0:
-            dz = -1
-            dx = -np.cos(self.theta) * np.cos(self.phi) / np.sin(self.phi)
-            dy = -np.sin(self.theta) * np.cos(self.phi) / np.sin(self.phi)
-        elif self.pz != 0:
-            dz = 1
-            dx = np.cos(self.theta) * np.cos(self.phi) / np.sin(self.phi)
-            dy = np.sin(self.theta) * np.cos(self.phi) / np.sin(self.phi)
-        else:
-            dz = 0
-            dx = np.cos(self.theta) * np.cos(self.phi)
-            dy = np.sin(self.theta) * np.cos(self.phi) #Un-normalised for the rare case of phi=0
-        return dx, dy, dz
+    def batch_calculate_direction(pz, theta, phi):
+        # im pretty certain we avoid division by zero if we avoid tan(phi) entirely, dz=0 should have a valid direction vector right?
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        cos_phi = np.cos(phi)
+        sin_phi = np.sin(phi)
+        dx = cos_theta * cos_phi 
+        dy = sin_theta * cos_phi
+        dz = sin_phi
+        
+        return np.column_stack([dx, dy, dz])
 
     def get_origin(self):
         return (self.x, self.y, self.z)


### PR DESCRIPTION
- Changed photon generation to vectorized numpy (numpy.random.uniform)
- Introduced batch processing for better ram usage 
    - speeds up calculation by a significant amount
    - allows for processing up to 10m photons at a similar (slightly slower) speed than 100k previously
    - I haven't noticed an improvement beyond 100k batches but im pretty sure its ram dependent.
- detects_batch function in naitl.py
- batch_calculate_direction function in photon.py
- Slight change which should avoid tan(phi)
- Removed Herobrine